### PR TITLE
Add command to interactively select a date to run a report on

### DIFF
--- a/hledger-mode.el
+++ b/hledger-mode.el
@@ -106,6 +106,7 @@ COMMAND, ARG and IGNORED the regular meanings."
     (define-key map (kbd "w") 'hledger-widen-results-for-register)
     (define-key map (kbd "<") 'hledger-prev-report)
     (define-key map (kbd ">") 'hledger-next-report)
+    (define-key map (kbd "D") 'hledger-report-at-day)
     (define-key map (kbd ".") 'hledger-present-report)
     (define-key map (kbd "o") (hledger-as-command hledger-overall-report*
                                                   "overall"))


### PR DESCRIPTION
When a report is shown, running `(hledger-report-at-day)` will allow the user to select the date at which the report should be shown.

I added a binding to that command but I'm happy to change it if another one makes more sense.