### PR TITLE
Escape the currency string when using it in regexps

### DIFF
--- a/hledger-core.el
+++ b/hledger-core.el
@@ -72,12 +72,12 @@
 
 (defun hledger-amount-regex ()
   "Regular expression to match an inserted amount in rupees."
-  (format "\\<%s\\s-*[-]?[0-9,]+\\(\\.[0-9]+\\)?\\>" hledger-currency-string))
+  (format "\\<%s\\s-*[-]?[0-9,]+\\(\\.[0-9]+\\)?\\>" (regexp-quote hledger-currency-string)))
 
 (defun hledger-whitespace-amount-regex ()
   "Regular expression for whitespace followed by amount."
   (format "\\s-*%s" (format "\\<%s\\s-*[-]?[0-9]+\\(\\.[0-9]+\\)?\\>"
-                                     hledger-currency-string)))
+                                     (regexp-quote hledger-currency-string))))
 
 ;;; Indentation
 (defun hledger-line-matchesp (re offset)
@@ -123,7 +123,7 @@
   "Return true if the account line has an amount."
   (hledger-cur-line-matchesp (concat hledger-whitespace-account-regex
                                      (format "\\s-*%s\\s-*$"
-                                             hledger-currency-string))))
+                                             (regexp-quote hledger-currency-string)))))
 (defun hledger-expecting-rupeep ()
   "Return true if we should insert a rupee sign."
   (hledger-cur-line-matchesp (concat hledger-whitespace-account-regex

--- a/hledger-defuns.el
+++ b/hledger-defuns.el
@@ -164,7 +164,7 @@ not balance at point."
           (goto-char end)
           (while (re-search-backward hledger-amount-regex beg t)
             (push (string-to-number (replace-regexp-in-string
-                                     hledger-currency-string
+                                     (regexp-quote hledger-currency-string)
                                      ""
                                      (match-string 0)))
                   amounts)))

--- a/hledger-reports.el
+++ b/hledger-reports.el
@@ -590,7 +590,7 @@ Optional argument END end date string for journal entries to consider."
                           (shell-quote-argument "\"%(account)\" %(total) "))))
          (elisp-string (concat "("
                                (replace-regexp-in-string
-                                (concat hledger-currency-string
+                                (concat (regexp-quote hledger-currency-string)
                                         "\\|-")
                                 ""
                                 output)


### PR DESCRIPTION
Fixes some errors when the currency is `$`.