### PR TITLE
Improve syntax highlighting

### DIFF
--- a/hledger-core.el
+++ b/hledger-core.el
@@ -57,7 +57,7 @@
 (defvar hledger-account-regex
   (concat "\\(\\([Rr]evenues?\\|[aA]ssets?\\|[lL]iabilit\\(?:ies\\|y\\)\\|[Dd]ebts?"
 	  "\\|[Ee]quity\\|[Ee]xpenses?\\|[iI]ncome\\|[Zz]adjustments?\\)" ;; terms all accounts must start with
-	  "\\(:[A-Za-z0-9\-]+\\( [A-Za-z0-9\-]+\\)*\\)*\\)"             ;; allow multi-word account names
+	  "\\(:\\([^[:space:];\n]+\\( [^[:space:];\n]+\\)*\\)\\)*\\)"             ;; allow multi-word account names
 	  )
   "Regular expression for a potential journal account.")
 

--- a/hledger-core.el
+++ b/hledger-core.el
@@ -55,9 +55,9 @@
   "Regular expression for matching a starting entry with some description.")
 
 (defvar hledger-account-regex
-  (concat "\\(\\([Rr]evenues?\\|[aA]ssets?\\|[lL]iabilit\\(?:ies\\|y\\)\\|[Dd]ebts?"
+  (concat "\\(\\(?:[Rr]evenues?\\|[aA]ssets?\\|[lL]iabilit\\(?:ies\\|y\\)\\|[Dd]ebts?"
 	  "\\|[Ee]quity\\|[Ee]xpenses?\\|[iI]ncome\\|[Zz]adjustments?\\)" ;; terms all accounts must start with
-	  "\\(:\\([^[:space:];\n]+\\( [^[:space:];\n]+\\)*\\)\\)*\\)"             ;; allow multi-word account names
+	  "\\(?::\\([^[:space:];\n]+\\(?: [^[:space:];=\n]+\\)*\\)\\)*\\)"             ;; allow multi-word account names
 	  )
   "Regular expression for a potential journal account.")
 

--- a/hledger-mode.el
+++ b/hledger-mode.el
@@ -125,7 +125,12 @@ COMMAND, ARG and IGNORED the regular meanings."
 (defun hledger-font-lock-keywords-1 ()
   "Minimal highlighting expressions for hledger mode."
   (list
-   `(,hledger-account-regex . hledger-account-face)
+   `(,(concat "^  +" hledger-account-regex) 1 hledger-account-face)
+   `(,(concat "^account " hledger-account-regex "$") 1 hledger-account-face)
+   `(,(concat "^alias \\([^[:space:]=;\n]+\\) = " hledger-account-regex "$")
+     (1 hledger-account-face)
+     (2 hledger-account-face))
+   `(,(concat "^payee " hledger-account-regex "$") 1 hledger-account-face)
    `(,hledger-date-regex . hledger-date-face)
    `(,(hledger-amount-regex) . hledger-amount-face)))
 

--- a/test/hledger-mode-test.el
+++ b/test/hledger-mode-test.el
@@ -16,9 +16,9 @@
   "Account name regex matches account name with a space"
   (should (equal (act-name-first-match "Revenues:Consulting Income") "Revenues:Consulting Income")))
 
-(ert-deftest ert-test-account-name-doesnt-include-amount ()
-  "Account name regex match does not include amount"
-  (should (equal (act-name-first-match "Revenues:Consulting Income $42.00") "Revenues:Consulting Income")))
+(ert-deftest ert-test-malformed-account-is-matched-fully ()
+  "Account name regex match does include amount when not correctly separated"
+  (should (equal (act-name-first-match "Revenues:Consulting Income $42.00") "Revenues:Consulting Income $42.00")))
 
 (ert-deftest ert-test-account-name-doesnt-match-if-starting-whitelist-not-matched ()
   "Account name regex match doesn't match if it does not start with a whitelisted word"
@@ -31,6 +31,16 @@
 (ert-deftest ert-test-account-name-nested ()
   "Account name may be nested more than one level"
   (should (equal (act-name-first-match "Revenues:Consulting Income:Haskell") "Revenues:Consulting Income:Haskell")))
+
+(ert-deftest ert-test-account-name-with-non-ascii-and-punctuation ()
+  "Account name regex matches account name with non-ASCII characters and punctuation"
+  (should (equal (act-name-first-match "Revenues:Consulting Income:Kö Pte. Ltd.") "Revenues:Consulting Income:Kö Pte. Ltd.")))
+
+(ert-deftest ert-test-account-name-doesnt-match-forbidden-characters ()
+  "Account name regex match stops at forbidden characters"
+  (let ((m (string-match hledger-account-regex "Revenues:Consulting Income:Company;Co")))
+    (should (= (match-beginning 0) 0))
+    (should (= (match-end 0) 34))))
 
 
 (setq hledger-currency-string "$")


### PR DESCRIPTION
I noticed account names with punctuation or non-ASCII characters in them weren’t being matched in full even though hledger recognizes them, so I updated the regex to be more permissive. That led to some odd highlighting since it was being matched anywhere; for example, `Income:` was highlighted in a line like `2023-06-23 Income: Fictional open source profits`. My solution was to replace the blanket font lock rule with separate rules for each of the four places I’m aware of where an account can appear: in a posting, and in three directives (`alias`, `account` & `payee`).

This is technically backwards-incompatible. A line like `Revenues:Something $42.00` was previously parsed as an account followed by an amount. With this PR, the entire thing is recognized as an account, like in hledger itself.