### PR TITLE
Improve account completion and highlighting

### DIFF
--- a/hledger-core.el
+++ b/hledger-core.el
@@ -58,6 +58,10 @@
 	"\\(\\([^[:space:];\n]+\\(?: [^[:space:];=\n]+\\)*\\)\\)"
   "Regular expression for a potential journal account.")
 
+(defvar hledger-account-leading-regex
+  "/\\|\\(= \\)\\|\\(?:  \\)"
+  "Regular expression for places where an account name can begin.")
+
 (defvar hledger-whitespace-account-regex (format "\\s-*%s" hledger-account-regex)
   "Regular expression for an account with leading whitespace.")
 (defvar hledger-comment-regex "^[ \t]*;"

--- a/hledger-core.el
+++ b/hledger-core.el
@@ -55,10 +55,7 @@
   "Regular expression for matching a starting entry with some description.")
 
 (defvar hledger-account-regex
-  (concat "\\(\\(?:[Rr]evenues?\\|[aA]ssets?\\|[lL]iabilit\\(?:ies\\|y\\)\\|[Dd]ebts?"
-	  "\\|[Ee]quity\\|[Ee]xpenses?\\|[iI]ncome\\|[Zz]adjustments?\\)" ;; terms all accounts must start with
-	  "\\(?::\\([^[:space:];\n]+\\(?: [^[:space:];=\n]+\\)*\\)\\)*\\)"             ;; allow multi-word account names
-	  )
+	"\\(\\([^[:space:];\n]+\\(?: [^[:space:];=\n]+\\)*\\)\\)"
   "Regular expression for a potential journal account.")
 
 (defvar hledger-whitespace-account-regex (format "\\s-*%s" hledger-account-regex)

--- a/hledger-defuns.el
+++ b/hledger-defuns.el
@@ -342,10 +342,14 @@ looks ugly when it's small."
 (defun hledger-completion-at-point ()
   "Adding this for account name completions in `minibuffer'."
   (interactive)
-  (let* ((bounds (bounds-of-thing-at-point 'word))
-         (start (car bounds))
-         (end (cdr bounds)))
-    (list start end hledger-accounts-cache . nil)))
+  (let ((bounds
+         (or (bounds-of-thing-at-point 'hledger-account)
+             (bounds-of-thing-at-point 'symbol))))
+    (when bounds
+      (list (car bounds)
+            (cdr bounds)
+            hledger-accounts-cache
+            :exclusive 'no))))
 
 
 (provide 'hledger-defuns)

--- a/hledger-mode.el
+++ b/hledger-mode.el
@@ -158,7 +158,9 @@ COMMAND, ARG and IGNORED the regular meanings."
   (when hledger-enable-current-overlay
     (add-hook 'post-command-hook 'hledger-update-current-entry-overlay))
   ;; How can make this execute lazily?
-  (setq hledger-accounts-cache (hledger-get-accounts)))
+  (setq hledger-accounts-cache (hledger-get-accounts))
+  (add-to-list (make-local-variable 'completion-at-point-functions)
+               'hledger-completion-at-point))
 
 ;;;###autoload
 (define-derived-mode hledger-mode fundamental-mode "HLedger" ()

--- a/hledger-navigate.el
+++ b/hledger-navigate.el
@@ -212,8 +212,10 @@ Optional argument SEP-REGEXP is the regular expression that separates things."
       (cons new-x (line-end-position)))))
 
 (defun hledger-bounds-of-account-at-point ()
-    "Return the bounds of an account name at point."
-  (hledger-bounds-of-thing-at-point hledger-account-regex))
+  "Return the bounds of an account name at point."
+  (let ((entry-bounds (hledger-bounds-of-current-entry)))
+    (when (thing-at-point-looking-at hledger-account-regex (- (cdr entry-bounds) (car entry-bounds)))
+      (cons (match-beginning 0) (match-end 0)))))
 
 (defun hledger-bounds-of-date-at-point ()
     "Return the bounds of date at point."

--- a/hledger-navigate.el
+++ b/hledger-navigate.el
@@ -213,8 +213,18 @@ Optional argument SEP-REGEXP is the regular expression that separates things."
 
 (defun hledger-bounds-of-account-at-point ()
   "Return the bounds of an account name at point."
-  (let ((entry-bounds (hledger-bounds-of-current-entry)))
-    (when (thing-at-point-looking-at hledger-account-regex (- (cdr entry-bounds) (car entry-bounds)))
+  (let ((start (or (save-excursion
+                     (re-search-backward hledger-account-leading-regex (point-at-bol) t)
+                     (goto-char (match-end 0))
+                     (point))
+                   (point-at-bol)))
+        (end (or (save-excursion
+                   (re-search-forward hledger-account-leading-regex (point-at-eol) t)
+                   (point))
+                 (point-at-eol))))
+    (when (and (thing-at-point-looking-at hledger-account-regex (- end start))
+               (>= (match-beginning 0) start)
+               (<= (match-end 0) end))
       (cons (match-beginning 0) (match-end 0)))))
 
 (defun hledger-bounds-of-date-at-point ()

--- a/hledger-reports.el
+++ b/hledger-reports.el
@@ -325,7 +325,7 @@ STRING can be multiple words separated by a space."
                                    hledger-jfile
                                    " accounts "
                                    (or string ""))))
-         (accounts-list (split-string accounts-string)))
+         (accounts-list (split-string accounts-string "\n")))
     accounts-list))
 
 (defun hledger-get-balances (accounts)


### PR DESCRIPTION
Given that #46 makes syntax highlighting for accounts context sensitive, and based on the discussion in the comments, I took a stab at improving completion for accounts, which also involved improving the syntax highlighting a bit further. This PR makes the following changes:

1. Remove the requirement for accounts to start with a recognized prefix. An alias `foo` will now be properly parsed as an account in the appropriate places, and so will regular accounts with unorthodox naming.
2. When retrieving the list of accounts via <kbd>hledger accounts</kbd>, split at newlines instead of all whitespace. This allows completing all of `expenses:pa`, `expenses:payee w`, and `expenses:payee with s` to `expenses:payee with spaces`.
3. Enable `hledger-completion-at-point` by default in `hledger-mode`.

I also improved `hledger-bounds-of-account-at-point` to prevent runaway highlighting and added a few tests to verify its behaviour. I’m sorry they don’t quite match the style of the rest of the tests… I wanted to test different positions in the same document, and this seemed like the most straightforward method. Please do let me know if you can think of a better approach.