### PR TITLE
Allow highlighting colons within accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ to your Emacs add it to `load-path`.
     (lambda ()
         (setq-local ac-sources '(hledger-ac-source))))
 
+;; To make colons in account names stand out,
+(defface hledger-account-colon-face
+    '((t :inherit font-lock-variable-name-face
+         :weight bold))
+    "Face for hledger account colons (signifying subheads)."
+    :group 'hledger)
+
+(setq hledger-account-colon-face 'hledger-account-colon-face)
 ```
 
 ## Configuration


### PR DESCRIPTION
This might be a niche requirement, but I really wanted something that makes the colons in account names stand out. This PR adjusts the fontification to give them `hledger-account-colon-face`, which is the same as `hledger-account-face` by default, so the behaviour is opt-in. Here’s an example of a very… virulent configuration for the sake of demonstration:

![](https://github.com/narendraj9/hledger-mode/assets/7817352/616452fc-d1e4-4a1d-80c5-67e1f2d8a903)

I also added a test for fontification using the same text, because there are some tricky details to watch out for (like the colons I deliberately included in the description and the comments).

I’ll understand if this is too specific to merit inclusion in the project, of course.