### PR TITLE
Improve completion

### DIFF
--- a/hledger-defuns.el
+++ b/hledger-defuns.el
@@ -340,15 +340,23 @@ looks ugly when it's small."
                  " "))))
 
 (defun hledger-update-accounts (&optional buffer)
-  "Update `hledger-accounts-cache'. Will do nothing
+  "Update `hledger-accounts-cache' and unset
+`hledger-must-update-accounts'. Will do nothing
 if `buffer' is passed but inactive."
   (when (or (null buffer)
             (eql (current-buffer) buffer))
-    (setq hledger-accounts-cache (hledger-get-accounts))))
+    (setq hledger-accounts-cache (hledger-get-accounts)
+          hledger-must-update-accounts nil)))
+
+(defun hledger-must-update-accounts ()
+  "Set the `hledger-must-update-accounts' flag to `t'."
+  (setq hledger-must-update-accounts t))
 
 (defun hledger-completion-at-point ()
   "Adding this for account name completions in `minibuffer'."
   (interactive)
+  (when hledger-must-update-accounts
+    (hledger-update-accounts))
   (let ((bounds
          (or (bounds-of-thing-at-point 'hledger-account)
              (bounds-of-thing-at-point 'symbol))))

--- a/hledger-defuns.el
+++ b/hledger-defuns.el
@@ -340,23 +340,29 @@ looks ugly when it's small."
                  " "))))
 
 (defun hledger-update-accounts (&optional buffer)
-  "Update `hledger-accounts-cache' and unset
-`hledger-must-update-accounts'. Will do nothing
+  "Update `hledger-accounts-cache' (optionally using `buffer' as
+input) and unset `hledger-must-update-accounts'. Will do nothing
 if `buffer' is passed but inactive."
   (when (or (null buffer)
             (eql (current-buffer) buffer))
-    (setq hledger-accounts-cache (hledger-get-accounts)
+    (setq hledger-accounts-cache (hledger-get-accounts nil buffer)
           hledger-must-update-accounts nil)))
+
+(defun hledger-maybe-update-accounts (&optional buffer)
+  "Set the `hledger-must-update-accounts' flag to `t' if the current
+command inserts text."
+  (when (eql this-command 'self-insert-command)
+    (hledger-must-update-accounts)))
 
 (defun hledger-must-update-accounts ()
   "Set the `hledger-must-update-accounts' flag to `t'."
   (setq hledger-must-update-accounts t))
 
 (defun hledger-completion-at-point ()
-  "Adding this for account name completions in `minibuffer'."
+  "Provide completion for accounts."
   (interactive)
   (when hledger-must-update-accounts
-    (hledger-update-accounts))
+    (hledger-update-accounts (current-buffer)))
   (let ((bounds
          (or (bounds-of-thing-at-point 'hledger-account)
              (bounds-of-thing-at-point 'symbol))))

--- a/hledger-defuns.el
+++ b/hledger-defuns.el
@@ -339,6 +339,13 @@ looks ugly when it's small."
                           "")))
                  " "))))
 
+(defun hledger-update-accounts (&optional buffer)
+  "Update `hledger-accounts-cache'. Will do nothing
+if `buffer' is passed but inactive."
+  (when (or (null buffer)
+            (eql (current-buffer) buffer))
+    (setq hledger-accounts-cache (hledger-get-accounts))))
+
 (defun hledger-completion-at-point ()
   "Adding this for account name completions in `minibuffer'."
   (interactive)

--- a/hledger-mode.el
+++ b/hledger-mode.el
@@ -172,7 +172,7 @@ COMMAND, ARG and IGNORED the regular meanings."
             (lambda () (cancel-timer hledger-update-accounts-timer))
             nil
             t)
-  (add-hook 'after-save-hook 'hledger-must-update-accounts nil t)
+  (add-hook 'post-command-hook 'hledger-maybe-update-accounts nil t)
   (add-to-list (make-local-variable 'completion-at-point-functions)
                'hledger-completion-at-point))
 

--- a/hledger-mode.el
+++ b/hledger-mode.el
@@ -58,11 +58,15 @@
   :type 'face
   :group 'hledger)
 
-(defcustom hledger-update-accounts-idle-delay 0.3
+(defcustom hledger-update-accounts-idle-delay 1
   "Update accounts in file when Emacs has been idle for this many seconds.")
 
 (defvar hledger-accounts-cache nil
   "List of accounts cached for ac and company modes.")
+
+(defvar hledger-must-update-accounts nil
+  "Flag indicating that the list of accounts has potentially changed
+and must be recomputed. For internal use.")
 
 (defvar hledger-ac-source
   `((init . hledger-get-accounts)
@@ -168,6 +172,7 @@ COMMAND, ARG and IGNORED the regular meanings."
             (lambda () (cancel-timer hledger-update-accounts-timer))
             nil
             t)
+  (add-hook 'after-save-hook 'hledger-must-update-accounts nil t)
   (add-to-list (make-local-variable 'completion-at-point-functions)
                'hledger-completion-at-point))
 

--- a/hledger-reports.el
+++ b/hledger-reports.el
@@ -321,7 +321,7 @@ non-nil, it lands us in the `hledger-mode' ."
   "Return list of account names with STRING infix present.
 STRING can be multiple words separated by a space."
   (let* ((accounts-string (shell-command-to-string
-                           (concat "hledger -f"
+                           (concat "hledger -I -f"
                                    hledger-jfile
                                    " accounts "
                                    (or string ""))))

--- a/hledger-reports.el
+++ b/hledger-reports.el
@@ -325,7 +325,7 @@ STRING can be multiple words separated by a space."
                                    hledger-jfile
                                    " accounts "
                                    (or string ""))))
-         (accounts-list (split-string accounts-string "\n")))
+         (accounts-list (split-string (string-trim-right accounts-string) "\n")))
     accounts-list))
 
 (defun hledger-get-balances (accounts)

--- a/hledger-reports.el
+++ b/hledger-reports.el
@@ -317,16 +317,23 @@ non-nil, it lands us in the `hledger-mode' ."
                                     (point-max)
                                     'next-error))
 
-(defun hledger-get-accounts (&optional string)
+(defun hledger-get-accounts (&optional string buffer)
   "Return list of account names with STRING infix present.
 STRING can be multiple words separated by a space."
-  (let* ((accounts-string (shell-command-to-string
-                           (concat "hledger -I -f"
-                                   hledger-jfile
-                                   " accounts "
-                                   (or string ""))))
-         (accounts-list (split-string (string-trim-right accounts-string) "\n")))
-    accounts-list))
+  (let* ((dest-buffer (make-temp-name "hledger-output-"))
+         (constant-args (list "-I" "-f" (if buffer "-" hledger-jfile) "accounts"))
+         (full-args (if (null string)
+                        constant-args
+                      (append constant-args (list string))))
+         (exit-code (if buffer
+                        (with-current-buffer buffer
+                          (apply #'call-process-region nil nil "hledger" nil dest-buffer nil full-args))
+                      (apply #'call-process "hledger" nil dest-buffer nil full-args)))
+         (output (string-trim-right (with-current-buffer dest-buffer
+                                      (buffer-string)))))
+    (kill-buffer dest-buffer)
+    (when (= exit-code 0)
+      (split-string output "\n"))))
 
 (defun hledger-get-balances (accounts)
   "Return balances for the sequence of ACCOUNTS."

--- a/test/hledger-mode-test.el
+++ b/test/hledger-mode-test.el
@@ -139,8 +139,9 @@ alias account4 = account3
           (should (equal hledger-accounts-cache '("account1" "account2" "account3")))
           (goto-char (point-max))
           (insert hledger-accounts-should-update-2)
-          (should (equal hledger-accounts-cache '("account1" "account2" "account3")))
-          (save-buffer)
+          ;; A bit of a hack to force an update.
+          (let ((this-command 'self-insert-command))
+            (run-hooks 'post-command-hook))
           (should (equal hledger-accounts-cache '("account1" "account2" "account3")))
           (hledger-completion-at-point)
           (should (equal hledger-accounts-cache '("account1" "account2" "account3" "account5"))))


### PR DESCRIPTION
In addition to resolving #49, this PR implements progressively more aggressive updates for the list of accounts:

1. When Emacs is idle (using `run-with-idle-timer`).
2. When `hledger-completion-at-point` is called after a save.
3. When `hledger-completion-at-point` is called after a change in the buffer (in which case it uses the contents as input to hledger).

Each of these is a separate commit since I wasn’t sure how much would be acceptable. In the third case, account completion almost always has a very slight delay, since it’s unlikely you’ll be completing something with absolutely no input before that. I can barely perceive the delay, but I’m using a powerful machine, so I don’t want to generalize from my experience.

As I was working on this, I started wondering whether it’s a good idea for `hledger-accounts-cache` to be a global variable. I know the mode uses a single `hledger-jfile` variable, but this makes it hard to manage unrelated journals.