### PR TITLE
Add hledger-autosync-mode for automatic account synchronization

### DIFF
--- a/hledger-defuns.el
+++ b/hledger-defuns.el
@@ -72,6 +72,22 @@
     (insert entries)
     (format "Fetched entries appended.")))
 
+(defun hledger-autosync--setup-file ()
+  "Set up the current hledger file."
+  (when (eq major-mode 'hledger-mode)
+    (hledger-update-accounts)))
+
+(define-minor-mode hledger-autosync-mode
+  "Global minor mode for auto-syncing hledger files."
+  :global t
+  :init-value nil
+  (cond
+   (hledger-autosync-mode
+    (add-hook 'find-file-hook #'hledger-autosync--setup-file))
+   (t
+    (remove-hook 'find-file-hook #'hledger-autosync--setup-file))))
+
+
 (defmacro hledger-as-command (name command)
   "Define a function named NAME for hledger COMMAND."
   `(defun ,(intern (symbol-name name)) () (interactive)
@@ -340,6 +356,7 @@ looks ugly when it's small."
                  " "))))
 
 (defun hledger-update-accounts (&optional buffer)
+  (interactive)
   "Update `hledger-accounts-cache' (optionally using `buffer' as
 input) and unset `hledger-must-update-accounts'. Will do nothing
 if `buffer' is passed but inactive."


### PR DESCRIPTION
## Dynamic Configuration of hledger Folders with dir-locals

Imagine you have multiple hledger folders for different finances. This case could be quite common. For example, you could have different hledger folders for your company and your private finances.

You can use `dir-locals` to set the hledger configuration dynamically.

```emacs-lisp
((nil .
      (
       (eval . (setq-local
		current-directory (expand-file-name (locate-dominating-file
						     default-directory ".dir-locals.el"))))
       (eval . (setq-local hledger-jfile (expand-file-name "main.journal"
							   current-directory)))
       )))
```

## The Issue with `hledger-accounts-cache`

The problem arises with the `hledger-accounts-cache` variable, which doesn't update automatically. To resolve this, I've written a hook. The existing "Find file" hook has limitations, particularly when the buffer is already loaded. 

Org Roam, which faces a similar issue with `org-roam-db-location`, also uses the "Find file" hook:

```emacs-lisp
(define-minor-mode org-roam-db-autosync-mode
  ...
  (let ((enabled org-roam-db-autosync-mode))
    (cond
     (enabled
      (add-hook 'find-file-hook  #'org-roam-db-autosync--setup-file-h)
      ;....
      (org-roam-db-sync))
     (t
      (remove-hook 'find-file-hook  #'org-roam-db-autosync--setup-file-h)
      ;....
      (org-roam-db--close-all)
      )))
```

## Workaround

As a workaround, you can manually execute `hledger-mode` in the other buffer to reload the accounts cache.

## Conclusion

I believe that this functionality is essential for making `hledger-mode` more dynamic and adaptable to different workflows.
