### PR TITLE
Ensure `iso8601-parse` is available for `hledger-add-days-to-entry-date`

### DIFF
--- a/hledger-navigate.el
+++ b/hledger-navigate.el
@@ -30,6 +30,7 @@
 
 (require 'hledger-core)
 (require 'pulse)
+(require 'parse-time)
 
 (defvar hledger-jentry-hook nil
   "Hook for `hledger-jentry'.")


### PR DESCRIPTION
A very small fix to address the error I reproduced from #56. I still want to run it by @narendraj9 to make sure requiring the library is alright. (It’s part of calendar, so it’s distributed with Emacs.)