### PR TITLE
allowed currency symbol to be read as prefix or suffix

### DIFF
--- a/hledger-core.el
+++ b/hledger-core.el
@@ -72,8 +72,10 @@
   "Regular expression to match a floating point number.")
 
 (defun hledger-amount-regex ()
-  "Regular expression to match an inserted amount in rupees."
-  (format "\\<%s\\s-*[-]?[0-9,]+\\(\\.[0-9]+\\)?\\>" (regexp-quote hledger-currency-string)))
+  "Regular expression to match an inserted amount with currency symbol as prefix or suffix."
+  (format "\\<\\(%s\\s-*[-]?[0-9,]+\\(\\.[0-9]+\\)?\\|[-]?[0-9,]+\\(\\.[0-9]+\\)?\\s-*%s\\)\\>"
+          (regexp-quote hledger-currency-string)
+          (regexp-quote hledger-currency-string)))
 
 (defun hledger-whitespace-amount-regex ()
   "Regular expression for whitespace followed by amount."

--- a/hledger-reports.el
+++ b/hledger-reports.el
@@ -593,7 +593,8 @@ Optional argument END is the --end date string for journal entries."
                           (mapconcat 'identity accounts-list " ")
                           (if beg (concat " --begin " beg) "")
                           " --end " (or end date-now)
-                          " --depth 1"
+                          " --depth 1 "
+                          " -V "
                           " --format "
                           (shell-quote-argument "\"%(account)\" %(total) "))))
          (elisp-string (concat "("

--- a/test/hledger-mode-test.el
+++ b/test/hledger-mode-test.el
@@ -38,12 +38,15 @@
     (should (= (match-beginning 0) 0))
     (should (= (match-end 0) 34))))
 
-
 (setq hledger-currency-string "$")
 
 (ert-deftest ert-test-amount-with-different-currency-string ()
   "Test matching an amount after changing the currency string to dollars"
   (should (equal (first-amount-match "$400.00") "$400.00")))
+
+(ert-deftest ert-test-amount-with-different-currency-string-as-suffix ()
+  "Test matching an amount after changing the currency string to dollars"
+  (should (equal (first-amount-match "400.00$") "400.00$")))
 
 (ert-deftest ert-test-amount-with-comma ()
   "Test amount matching containing a comma"


### PR DESCRIPTION
Fixes Issue #62 

I changed the regex to check for the currency symbol to be available before or affter the amout string and added a test. 

If there is anything wrong or to improve, let me know