### PR TITLE
Issue 66: hledger-add-days-to-entry-date off-by-one in some TZs

### DIFF
--- a/hledger-navigate.el
+++ b/hledger-navigate.el
@@ -124,7 +124,7 @@ subtract when `days 'is negative)."
            (new-date (encode-time (decoded-time-add parsed (make-decoded-time :day (floor days))))))
       (delete-region (line-beginning-position)
                      end)
-      (insert (format-time-string "%Y-%m-%d" new-date))
+      (insert (format-time-string "%Y-%m-%d" new-date t))
       (pulse-momentary-highlight-region (line-beginning-position)
                                         (line-end-position)))))
 


### PR DESCRIPTION
If the local time zone is behind UTC then hledger-add-days-to-entry-date gives an off-by-one error.  See #66 